### PR TITLE
Fix for all lights up on restart

### DIFF
--- a/src/main/kotlin/com/mqgateway/core/hardware/diozero/MCP23017.kt
+++ b/src/main/kotlin/com/mqgateway/core/hardware/diozero/MCP23017.kt
@@ -1,0 +1,72 @@
+package com.mqgateway.core.hardware.diozero
+
+import com.diozero.api.I2CDevice
+import com.diozero.devices.mcp23xxx.MCP23x17
+import com.diozero.util.MutableByte
+import org.tinylog.Logger
+
+/**
+ * This is modified copy of class com.diozero.devices.MCP23017
+ * It is modifying how MCP is initialised to avoid zeroing of all pins, which may cause light blinking or gates opening on UniGateway restart.
+ * This class also do not support interrupts for now, but it could be potentially implemented.
+ */
+open class MCP23017(controller: Int, address: Int, interruptGpioA: Int, interruptGpioB: Int) :
+  MCP23x17("$DEVICE_NAME-$controller-$address", interruptGpioA, interruptGpioB) {
+
+  private val device = I2CDevice.builder(address).setController(controller).build()
+
+  init {
+    initialiseWithoutZeroing()
+  }
+
+  override fun readByte(register: Int): Byte {
+    return device.readByteData(register)
+  }
+
+  override fun writeByte(register: Int, value: Byte) {
+    device.writeByteData(register, value)
+  }
+
+  private fun initialiseWithoutZeroing() {
+    // Initialise
+    // Read the I/O configuration value
+    val start_iocon = readByte(getIOConReg(0))
+    Logger.debug("Default power-on values for IOCON: 0x{}", Integer.toHexString(start_iocon.toInt()))
+    Logger.debug("IOCONB: 0x{}", Integer.toHexString(readByte(getIOConReg(1)).toInt()))
+
+    // Configure interrupts
+    val iocon = MutableByte(start_iocon)
+    iocon.unsetBit(IOCON_BANK_BIT)
+    iocon.setBit(IOCON_SEQOP_BIT)
+    iocon.unsetBit(IOCON_DISSLW_BIT)
+    iocon.setBit(IOCON_HAEN_BIT)
+    iocon.unsetBit(IOCON_ODR_BIT)
+    if (!iocon.equals(start_iocon)) {
+      writeByte(getIOConReg(0), iocon.value)
+    }
+    for (port in 0 until NUM_PORTS) {
+      // Default all GPIOs to output
+      writeByte(getIODirReg(port), 0.toByte())
+      // Default to normal input polarity - IPOLA/IPOLB
+      writeByte(getIPolReg(port), 0.toByte())
+      // Disable interrupt-on-change for all GPIOs
+      writeByte(getGPIntEnReg(port), 0.toByte())
+      // Set default compare values to 0
+      writeByte(getDefValReg(port), 0.toByte())
+      // Disable interrupt comparison control
+      writeByte(getIntConReg(port), 0.toByte())
+      // Disable pull-up resistors
+      writeByte(getGPPullUpReg(port), 0.toByte())
+    }
+  }
+
+  companion object {
+    private const val DEVICE_NAME = "MCP23017"
+    private const val IOCON_BANK_BIT: Byte = 7
+    private const val IOCON_SEQOP_BIT: Byte = 5
+    private const val IOCON_DISSLW_BIT: Byte = 4
+    private const val IOCON_HAEN_BIT: Byte = 3
+    private const val IOCON_ODR_BIT: Byte = 2
+    private const val NUM_PORTS = 2
+  }
+}

--- a/src/main/kotlin/com/mqgateway/core/hardware/mqgateway/mcp/MqGatewayMcpExpander.kt
+++ b/src/main/kotlin/com/mqgateway/core/hardware/mqgateway/mcp/MqGatewayMcpExpander.kt
@@ -2,7 +2,7 @@ package com.mqgateway.core.hardware.mqgateway.mcp
 
 import com.diozero.api.GpioEventTrigger
 import com.diozero.api.GpioPullUpDown
-import com.diozero.devices.MCP23017
+import com.mqgateway.core.hardware.diozero.MCP23017
 import com.mqgateway.core.io.BinaryState
 import com.mqgateway.core.io.BinaryState.HIGH
 import com.mqgateway.core.io.BinaryState.LOW
@@ -90,10 +90,11 @@ class MqGatewayMcpExpander(
 
   fun getOutputPin(gpioNumber: Int): MqGatewayMcpExpanderOutputPin {
     usedPins[gpioNumber]?.let { throw McpExpanderPinAlreadyInUseException(gpioNumber, it) }
+    val currentValue = mcp23017.getValue(gpioNumber)
     mcp23017.createDigitalOutputDevice(
       UUID.randomUUID().toString(),
       mcp23017.boardPinInfo.getByGpioNumberOrThrow(gpioNumber),
-      false
+      currentValue
     )
 
     usedPins[gpioNumber] = GpioType.OUTPUT

--- a/src/main/kotlin/com/mqgateway/core/hardware/mqgateway/mcp/MqGatewayMcpExpanders.kt
+++ b/src/main/kotlin/com/mqgateway/core/hardware/mqgateway/mcp/MqGatewayMcpExpanders.kt
@@ -1,8 +1,8 @@
 package com.mqgateway.core.hardware.mqgateway.mcp
 
 import com.diozero.api.I2CConstants
-import com.diozero.devices.MCP23017
 import com.diozero.devices.mcp23xxx.MCP23xxx.INTERRUPT_GPIO_NOT_SET
+import com.mqgateway.core.hardware.diozero.MCP23017
 import com.mqgateway.core.hardware.mqgateway.WireColor
 import com.mqgateway.core.io.BinaryInput
 import com.mqgateway.core.io.BinaryOutput

--- a/src/test/groovy/com/mqgateway/core/hardware/mqgateway/mcp/MqGatewayMcpExpanderTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/hardware/mqgateway/mcp/MqGatewayMcpExpanderTest.groovy
@@ -5,8 +5,8 @@ import static com.mqgateway.core.hardware.mqgateway.mcp.MqGatewayMcpExpander.GPI
 import static com.mqgateway.core.io.BinaryState.HIGH
 import static com.mqgateway.core.io.BinaryState.LOW
 
-import com.diozero.devices.MCP23017
 import com.diozero.sbc.BoardPinInfo
+import com.mqgateway.core.hardware.diozero.MCP23017
 import com.mqgateway.core.io.BinaryState
 import java.time.Duration
 import spock.lang.Specification
@@ -196,6 +196,20 @@ class MqGatewayMcpExpanderTest extends Specification {
 
     then:
     thrown(IncorrectGpioTypeException)
+  }
+
+  def "should not change pin state when getting output pin"() {
+    given:
+    mcpMock.getValue(1) >> initialPinValue
+
+    when:
+    expander.getOutputPin(1)
+
+    then:
+    1 * mcpMock.createDigitalOutputDevice(_, _, initialPinValue)
+
+    where:
+    initialPinValue << [true, false]
   }
 
   def "should fail with exception when trying to write state from pin set to be INPUT"() {


### PR DESCRIPTION
There were two problems:
- implementation of initialisation of MCP23017 in diozero library
- setting default initial value of output pin to 0 in MqGateway hardware implementation

I've created [pull request on diozero library](https://github.com/mattjlewis/diozero/pull/99) to solve that. However, in the meantime we can use overridden MCP23017 class with slightly changed implementaiton comparing to diozero.

For the issue in MqGateway hardware implementation, simple fix has been applied. 