### PR TITLE
Adjusting devices and entities naming to the Home Assistant MQTT name changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 micronautVersion=3.3.3
-kotlinVersion=1.6.10
+kotlinVersion=1.9.23

--- a/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantComponent.kt
+++ b/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantComponent.kt
@@ -1,6 +1,7 @@
 package com.mqgateway.core.gatewayconfig.homeassistant
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 
@@ -11,10 +12,12 @@ abstract class HomeAssistantComponent(
   protected fun uniqueId() = properties.uniqueId()
 }
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class HomeAssistantComponentBasicProperties(
   @field:JsonProperty("device") val device: HomeAssistantDevice? = null,
   @JsonIgnore val nodeId: String,
-  @JsonIgnore val objectId: String
+  @field:JsonProperty("object_id") val objectId: String,
+  @field:JsonProperty("name") val name: String? = null,
 ) {
   fun uniqueId() = "${nodeId}_$objectId"
 }
@@ -39,7 +42,6 @@ enum class HomeAssistantComponentType(val value: String) {
 
 data class HomeAssistantLight(
   @JsonIgnore val basicProperties: HomeAssistantComponentBasicProperties,
-  @field:JsonProperty("name") val name: String,
   @field:JsonProperty("state_topic") val stateTopic: String,
   @field:JsonProperty("command_topic") val commandTopic: String,
   @field:JsonProperty("retain") val retain: Boolean,
@@ -51,7 +53,6 @@ data class HomeAssistantLight(
 
 data class HomeAssistantSwitch(
   @JsonIgnore val basicProperties: HomeAssistantComponentBasicProperties,
-  @field:JsonProperty("name") val name: String,
   @field:JsonProperty("state_topic") val stateTopic: String,
   @field:JsonProperty("command_topic") val commandTopic: String,
   @field:JsonProperty("retain") val retain: Boolean,
@@ -77,7 +78,6 @@ data class HomeAssistantSwitch(
 
 data class HomeAssistantBinarySensor(
   @JsonIgnore val basicProperties: HomeAssistantComponentBasicProperties,
-  @field:JsonProperty("name") val name: String,
   @field:JsonProperty("state_topic") val stateTopic: String,
   @field:JsonProperty("payload_on") val payloadOn: String,
   @field:JsonProperty("payload_off") val payloadOff: String,
@@ -128,7 +128,6 @@ data class HomeAssistantBinarySensor(
 
 data class HomeAssistantSensor(
   @JsonIgnore val basicProperties: HomeAssistantComponentBasicProperties,
-  @field:JsonProperty("name") val name: String,
   @field:JsonProperty("availability_topic") val availabilityTopic: String? = null,
   @field:JsonProperty("payload_available") val payloadAvailable: String? = null,
   @field:JsonProperty("payload_not_available") val payloadNotAvailable: String? = null,
@@ -222,7 +221,6 @@ data class HomeAssistantTrigger(
 
 data class HomeAssistantCover(
   @JsonIgnore val basicProperties: HomeAssistantComponentBasicProperties,
-  @field:JsonProperty("name") val name: String,
   @field:JsonProperty("state_topic") val stateTopic: String?,
   @field:JsonProperty("command_topic") val commandTopic: String,
   @field:JsonProperty("position_topic") val positionTopic: String?,

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverterTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverterTest.groovy
@@ -50,7 +50,7 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantLight lightComponent = components[0] as HomeAssistantLight
     lightComponent.componentType == HomeAssistantComponentType.LIGHT
-    lightComponent.name == "Test relay"
+    lightComponent.properties.name == ""
     lightComponent.properties.nodeId == gateway.id
     lightComponent.properties.objectId == "myRelay"
     lightComponent.stateTopic == expectedStateTopic(gateway.id, relayDeviceConfig.id, STATE.toString())
@@ -75,7 +75,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantSwitch switchComponent = components[0] as HomeAssistantSwitch
     switchComponent.componentType == HomeAssistantComponentType.SWITCH
-    switchComponent.name == "Test relay"
     switchComponent.properties.nodeId == gateway.id
     switchComponent.properties.objectId == "myRelay"
     switchComponent.stateTopic == expectedStateTopic(gateway.id, relayDeviceConfig.id, STATE.toString())
@@ -156,7 +155,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantSensor sensorComponent = components[0] as HomeAssistantSensor
     sensorComponent.componentType == HomeAssistantComponentType.SENSOR
-    sensorComponent.name == "Test button"
     sensorComponent.properties.nodeId == gateway.id
     sensorComponent.properties.objectId == "mySwitchButton"
     sensorComponent.stateTopic == expectedStateTopic(gateway.id, switchButtonDeviceConfig.id, STATE.toString())
@@ -180,7 +178,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantBinarySensor binarySensorComponent = components[0] as HomeAssistantBinarySensor
     binarySensorComponent.componentType == HomeAssistantComponentType.BINARY_SENSOR
-    binarySensorComponent.name == "Test button"
     binarySensorComponent.properties.nodeId == gateway.id
     binarySensorComponent.properties.objectId == switchButtonDeviceConfig.id
     binarySensorComponent.stateTopic == expectedStateTopic(gateway.id, switchButtonDeviceConfig.id, STATE.toString())
@@ -206,7 +203,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantBinarySensor binarySensorComponent = components[0] as HomeAssistantBinarySensor
     binarySensorComponent.componentType == HomeAssistantComponentType.BINARY_SENSOR
-    binarySensorComponent.name == "Test reed switch"
     binarySensorComponent.properties.nodeId == gateway.id
     binarySensorComponent.properties.objectId == "myReedSwitch"
     binarySensorComponent.stateTopic == expectedStateTopic(gateway.id, reedSwitchDeviceConfig.id, STATE.toString())
@@ -251,7 +247,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantBinarySensor binarySensorComponent = components[0] as HomeAssistantBinarySensor
     binarySensorComponent.componentType == HomeAssistantComponentType.BINARY_SENSOR
-    binarySensorComponent.name == "Test motion detector"
     binarySensorComponent.properties.nodeId == gateway.id
     binarySensorComponent.properties.objectId == "myMotionDetector"
     binarySensorComponent.stateTopic == expectedStateTopic(gateway.id, motionDetectorDeviceConfig.id, STATE.toString())
@@ -276,7 +271,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 1
     HomeAssistantSwitch switchComponent = components[0] as HomeAssistantSwitch
     switchComponent.componentType == HomeAssistantComponentType.SWITCH
-    switchComponent.name == "Test emulated switch"
     switchComponent.properties.nodeId == gateway.id
     switchComponent.properties.objectId == "myEmulatedSwitch"
     switchComponent.stateTopic == expectedStateTopic(gateway.id, emulatedSwitchDeviceConfig.id, STATE.toString())
@@ -307,7 +301,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 3
     HomeAssistantCover cover = components.find { it.componentType == HomeAssistantComponentType.COVER }
     cover.deviceClass == HomeAssistantCover.DeviceClass.SHUTTER
-    cover.name == "Test shutter device"
     cover.properties.nodeId == gateway.id
     cover.properties.objectId == "myShutter"
     cover.stateTopic == expectedStateTopic(gateway.id, shutterDevice.id, STATE.toString())
@@ -355,7 +348,6 @@ class HomeAssistantConverterTest extends Specification {
     components.size() == 5
     HomeAssistantCover cover = components.find { it.componentType == HomeAssistantComponentType.COVER } as HomeAssistantCover
     cover.deviceClass == HomeAssistantCover.DeviceClass.GATE
-    cover.name == "Test gate device"
     cover.properties.nodeId == gateway.id
     cover.properties.objectId == "myGate"
     cover.stateTopic == expectedStateTopic(gateway.id, gateDevice.id, STATE.toString())
@@ -403,22 +395,22 @@ class HomeAssistantConverterTest extends Specification {
       assert sensorComponent.payloadNotAvailable == "lost"
     }
 
-    temperature.name == "CPU temperature"
+    temperature.properties.name == "CPU temperature"
     temperature.stateTopic == expectedStateTopic(gateway.id, gateway.id, TEMPERATURE.toString())
     temperature.unitOfMeasurement == DataUnit.CELSIUS.value
     temperature.properties.objectId == gateway.id + "_CPU_TEMPERATURE"
     temperature.uniqueId == gateway.id + "_" + gateway.id + "_CPU_TEMPERATURE"
-    freeMemory.name == "Free memory"
+    freeMemory.properties.name == "Free memory"
     freeMemory.stateTopic == expectedStateTopic(gateway.id, gateway.id, MEMORY.toString())
     freeMemory.unitOfMeasurement == DataUnit.BYTES.value
     freeMemory.properties.objectId == gateway.id + "_MEMORY_FREE"
     freeMemory.uniqueId == gateway.id + "_" + gateway.id + "_MEMORY_FREE"
-    uptime.name == "Uptime"
+    uptime.properties.name == "Uptime"
     uptime.stateTopic == expectedStateTopic(gateway.id, gateway.id, UPTIME.toString())
     uptime.unitOfMeasurement == DataUnit.SECOND.value
     uptime.properties.objectId == gateway.id + "_UPTIME"
     uptime.uniqueId == gateway.id + "_" + gateway.id + "_UPTIME"
-    ipAddress.name == "IP address"
+    ipAddress.properties.name == "IP address"
     ipAddress.stateTopic == expectedStateTopic(gateway.id, gateway.id, IP_ADDRESS.toString())
     ipAddress.unitOfMeasurement == DataUnit.NONE.value
     ipAddress.properties.objectId == gateway.id + "_IP_ADDRESS"
@@ -444,7 +436,6 @@ class HomeAssistantConverterTest extends Specification {
     then:
     components.size() == 4
     HomeAssistantLight lightComponent = components.find { it.componentType == HomeAssistantComponentType.LIGHT } as HomeAssistantLight
-    lightComponent.name == "Test light"
     lightComponent.properties.nodeId == gateway.id
     lightComponent.properties.objectId == "myLight"
     lightComponent.stateTopic == expectedStateTopic(gateway.id, lightDeviceConfig.id, STATE.toString())
@@ -454,6 +445,25 @@ class HomeAssistantConverterTest extends Specification {
     lightComponent.payloadOff == "OFF"
     lightComponent.uniqueId == gateway.id + "_" + lightDeviceConfig.id
     assertHomeAssistantDevice(lightComponent, gateway, lightDeviceConfig)
+  }
+
+  def "should convert MqGateway device to HA entity with given entity name when entity name is set explicitly in gateway configuration"() {
+    given:
+    def relayDeviceConfig = new DeviceConfiguration("myRelay", "Test relay", DeviceType.RELAY, [state: new SimulatedConnector(1)],
+      [:], ["haComponent": "light", "haEntityName": "Special Entity Name"])
+    GatewayConfiguration gateway = new GatewayConfiguration("1.0", "unigateway-id", "Gateway name", [
+      relayDeviceConfig
+    ])
+    def deviceRegistry = deviceRegistryFactory.create(gateway)
+
+    when:
+    def components = converter.convert(deviceRegistry).findAll { isNotFromMqGatewayCore(it, gateway) }
+
+    then:
+    components.size() == 1
+    HomeAssistantLight lightComponent = components[0] as HomeAssistantLight
+    lightComponent.componentType == HomeAssistantComponentType.LIGHT
+    lightComponent.properties.name == "Special Entity Name"
   }
 
   private void assertHomeAssistantDevice(HomeAssistantComponent haComponent, GatewayConfiguration gateway, DeviceConfiguration deviceConfig) {

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantPublisherTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantPublisherTest.groovy
@@ -23,32 +23,37 @@ class HomeAssistantPublisherTest extends Specification {
 	def "should publish all components configurations to the proper MQTT topic"() {
 		given:
 		def component1 = new HomeAssistantLight(
-			new HomeAssistantComponentBasicProperties(haDevice, "someNodeId1", "someObjectId1"), "test1Name",
-			"someStateTopic1", "someCommandTopic1", true, "ONtest1", "OFFtest1")
+      new HomeAssistantComponentBasicProperties(haDevice, "someNodeId1", "someObjectId1", "test1Name"),
+      "someStateTopic1", "someCommandTopic1", true, "ONtest1", "OFFtest1")
 		def component2 = new HomeAssistantLight(
-			new HomeAssistantComponentBasicProperties(haDevice, "someNodeId2", "someObjectId2"), "test2Name",
-			"someStateTopic2", "someCommandTopic2", false, "ONtest2", "OFFtest2")
+      new HomeAssistantComponentBasicProperties(haDevice, "someNodeId2", "someObjectId2", "test2Name"),
+      "someStateTopic2", "someCommandTopic2", false, "ONtest2", "OFFtest2")
+		def component3 = new HomeAssistantLight(
+      new HomeAssistantComponentBasicProperties(haDevice, "someNodeId3", "someObjectId3", ""),
+      "someStateTopic3", "someCommandTopic3", false, "ONtest3", "OFFtest3")
 
 		when:
-		publisher.publish(mqttClientStub, "testRoot", [component1, component2])
+		publisher.publish(mqttClientStub, "testRoot", [component1, component2, component3])
 
 		then:
 		def publishedMessages = mqttClientStub.getPublishedMessages()
 		publishedMessages[0].topic == "testRoot/light/someNodeId1/someObjectId1/config"
 		publishedMessages[1].topic == "testRoot/light/someNodeId2/someObjectId2/config"
+		publishedMessages[2].topic == "testRoot/light/someNodeId3/someObjectId3/config"
 		assertJsonEqual(component1, new JsonSlurper().parseText(publishedMessages[0].payload) as Map)
 		assertJsonEqual(component2, new JsonSlurper().parseText(publishedMessages[1].payload) as Map)
+		assertJsonEqual(component3, new JsonSlurper().parseText(publishedMessages[2].payload) as Map)
 
 		publishedMessages.every { it.retain }
 	}
 
 	static void assertJsonEqual(HomeAssistantLight light, Map jsonLight) {
-		assert light.name == jsonLight.name
 		assert light.stateTopic == jsonLight.state_topic
 		assert light.commandTopic == jsonLight.command_topic
 		assert light.retain == jsonLight.retain
 		assert light.payloadOn == jsonLight.payload_on
 		assert light.payloadOff == jsonLight.payload_off
+		assert light.properties.name == jsonLight.name
 		assert light.properties.device.identifiers == jsonLight.device.identifiers
 		assert light.properties.device.name == jsonLight.device.name
 		assert light.properties.device.model == jsonLight.device.model


### PR DESCRIPTION
This may cause entity id changes in the Home Assistant. Home Assistant documentation ensures it doesn't,
but with some unfortunate order of restarts between HA and UniGateway I've seen this happen. Make sure your automations have correct entity id after updating UniGateway. This change also influences friendly name
which is displayed in the HA dashboards.

This is related to the changes described here:
- https://community.home-assistant.io/t/psa-mqtt-name-changes-in-2023-8/598099
- https://www.home-assistant.io/integrations/mqtt/#naming-of-mqtt-entities