### PR TITLE
Add "area" device config option for Home Assistant area auto-assignment

### DIFF
--- a/docs/docs/user-guide/integration.md
+++ b/docs/docs/user-guide/integration.md
@@ -14,6 +14,32 @@ After UniGateway start, you should be able to see all the UniGateway configured 
 
 If you want to disable broadcasting the Home Assistant configuration to MQTT, set environment variable `HOMEASSISTANT_ENABLED` to `false` (see [system configuration](configuration.md#system-configuration) for details). 
 
+#### Home Assistant device configuration
+
+The following per-device `config` options can be used to fine-tune how devices appear in Home Assistant:
+
+| Config key      | Description                                                                                                                                                | Example               |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+| `haComponent`   | Override the Home Assistant entity type (e.g. `light`, `switch`, `sensor`, `trigger`)                                                                      | `light`               |
+| `haDeviceClass` | Override the device class (e.g., [for sensor](https://www.home-assistant.io/integrations/sensor/#device-class))                                            | `door`, `temperature` |
+| `haEntityName`  | Custom entity name visible in Home Assistant                                                                                                               | `My light`            |
+| `haArea`        | Assign the device to a Home Assistant [area](https://www.home-assistant.io/docs/organizing/areas/) automatically (sets `suggested_area` in MQTT discovery) | `Living Room`         |
+
+All of these are optional. Example usage:
+
+```yaml
+devices:
+  - id: "living_room_light"
+    name: "Living room light"
+    type: RELAY
+    connectors:
+      state:
+        gpio: 17
+    config:
+      haComponent: "light"
+      haArea: "Living Room"
+```
+
 
 ## OpenHab
 

--- a/docs/docs/user-guide/integration.md
+++ b/docs/docs/user-guide/integration.md
@@ -23,7 +23,7 @@ The following per-device `config` options can be used to fine-tune how devices a
 | `haComponent`   | Override the Home Assistant entity type (e.g. `light`, `switch`, `sensor`, `trigger`)                                                                      | `light`               |
 | `haDeviceClass` | Override the device class (e.g., [for sensor](https://www.home-assistant.io/integrations/sensor/#device-class))                                            | `door`, `temperature` |
 | `haEntityName`  | Custom entity name visible in Home Assistant                                                                                                               | `My light`            |
-| `haArea`        | Assign the device to a Home Assistant [area](https://www.home-assistant.io/docs/organizing/areas/) automatically (sets `suggested_area` in MQTT discovery) | `Living Room`         |
+| `area`          | Assign the device to a Home Assistant [area](https://www.home-assistant.io/docs/organizing/areas/) automatically (sets `suggested_area` in MQTT discovery) | `Living Room`         |
 
 All of these are optional. Example usage:
 
@@ -37,7 +37,7 @@ devices:
         gpio: 17
     config:
       haComponent: "light"
-      haArea: "Living Room"
+      area: "Living Room"
 ```
 
 

--- a/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantComponent.kt
+++ b/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantComponent.kt
@@ -22,6 +22,7 @@ data class HomeAssistantComponentBasicProperties(
   fun uniqueId() = "${nodeId}_$objectId"
 }
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class HomeAssistantDevice(
   @field:JsonProperty("identifiers") val identifiers: List<String>,
   @field:JsonProperty("manufacturer") val manufacturer: String? = null,
@@ -29,6 +30,7 @@ data class HomeAssistantDevice(
   @field:JsonProperty("name") val name: String? = null,
   @field:JsonProperty("sw_version") val firmwareVersion: String? = null,
   @field:JsonProperty("via_device") val viaDevice: String? = null,
+  @field:JsonProperty("suggested_area") val suggestedArea: String? = null,
 )
 
 enum class HomeAssistantComponentType(val value: String) {

--- a/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverter.kt
+++ b/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverter.kt
@@ -33,7 +33,7 @@ class HomeAssistantConverter(private val gatewayFirmwareVersion: String) {
     val unigatewayId = uniGatewayDevice.id
     return mqGatewayCoreComponents +
       devices.flatMap { device ->
-        val suggestedArea = device.config[DEVICE_CONFIG_HA_AREA]
+        val suggestedArea = device.config[DEVICE_CONFIG_AREA]
         val haDevice =
           HomeAssistantDevice(
             identifiers = listOf("${unigatewayId}_${device.id}"),
@@ -338,6 +338,6 @@ class HomeAssistantConverter(private val gatewayFirmwareVersion: String) {
     const val DEVICE_CONFIG_HA_COMPONENT: String = "haComponent"
     const val DEVICE_CONFIG_HA_DEVICE_CLASS: String = "haDeviceClass"
     const val DEVICE_CONFIG_HA_ENTITY_NAME: String = "haEntityName"
-    const val DEVICE_CONFIG_HA_AREA: String = "haArea"
+    const val DEVICE_CONFIG_AREA: String = "area"
   }
 }

--- a/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverter.kt
+++ b/src/main/kotlin/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverter.kt
@@ -33,6 +33,7 @@ class HomeAssistantConverter(private val gatewayFirmwareVersion: String) {
     val unigatewayId = uniGatewayDevice.id
     return mqGatewayCoreComponents +
       devices.flatMap { device ->
+        val suggestedArea = device.config[DEVICE_CONFIG_HA_AREA]
         val haDevice =
           HomeAssistantDevice(
             identifiers = listOf("${unigatewayId}_${device.id}"),
@@ -41,6 +42,7 @@ class HomeAssistantConverter(private val gatewayFirmwareVersion: String) {
             viaDevice = unigatewayId,
             firmwareVersion = gatewayFirmwareVersion,
             model = "UniGateway ${device.type.name}",
+            suggestedArea = suggestedArea,
           )
         val entityName = device.config[DEVICE_CONFIG_HA_ENTITY_NAME] ?: ""
         val basicProperties = HomeAssistantComponentBasicProperties(haDevice, unigatewayId, device.id, entityName)
@@ -336,5 +338,6 @@ class HomeAssistantConverter(private val gatewayFirmwareVersion: String) {
     const val DEVICE_CONFIG_HA_COMPONENT: String = "haComponent"
     const val DEVICE_CONFIG_HA_DEVICE_CLASS: String = "haDeviceClass"
     const val DEVICE_CONFIG_HA_ENTITY_NAME: String = "haEntityName"
+    const val DEVICE_CONFIG_HA_AREA: String = "haArea"
   }
 }

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverterTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverterTest.groovy
@@ -466,6 +466,52 @@ class HomeAssistantConverterTest extends Specification {
     lightComponent.properties.name == "Special Entity Name"
   }
 
+  def "should set suggested_area when haArea is configured"() {
+    given:
+    def relayDeviceConfig = new DeviceConfiguration("myRelay", "Test relay", DeviceType.RELAY, [state: new SimulatedConnector(1)],
+      [:], ["haArea": "Living Room"])
+    GatewayConfiguration gateway = gateway([relayDeviceConfig])
+    def deviceRegistry = deviceRegistryFactory.create(gateway)
+
+    when:
+    def components = converter.convert(deviceRegistry).findAll { isNotFromMqGatewayCore(it, gateway) }
+
+    then:
+    components.size() == 1
+    components[0].properties.device.suggestedArea == "Living Room"
+  }
+
+  def "should not set suggested_area when haArea is not configured"() {
+    given:
+    def relayDeviceConfig = new DeviceConfiguration("myRelay", "Test relay", DeviceType.RELAY, [state: new SimulatedConnector(1)])
+    GatewayConfiguration gateway = gateway([relayDeviceConfig])
+    def deviceRegistry = deviceRegistryFactory.create(gateway)
+
+    when:
+    def components = converter.convert(deviceRegistry).findAll { isNotFromMqGatewayCore(it, gateway) }
+
+    then:
+    components.size() == 1
+    components[0].properties.device.suggestedArea == null
+  }
+
+  def "should set suggested_area on trigger components when haArea is configured"() {
+    given:
+    def switchButtonDeviceConfig = new DeviceConfiguration("mySwitchButton", "Test button", DeviceType.SWITCH_BUTTON,
+      [state: new SimulatedConnector(1)], [:], [haComponent: "device_automation", "haArea": "Hallway"])
+    GatewayConfiguration gateway = gateway([switchButtonDeviceConfig])
+    def deviceRegistry = deviceRegistryFactory.create(gateway)
+
+    when:
+    def components = converter.convert(deviceRegistry).findAll { isNotFromMqGatewayCore(it, gateway) }
+
+    then:
+    components.size() == 4
+    components.each {
+      assert it.properties.device.suggestedArea == "Hallway"
+    }
+  }
+
   private void assertHomeAssistantDevice(HomeAssistantComponent haComponent, GatewayConfiguration gateway, DeviceConfiguration deviceConfig) {
     assert haComponent.properties.device.firmwareVersion == firmwareVersion
     assert haComponent.properties.device.identifiers == [gateway.id + "_" + deviceConfig.id]

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverterTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantConverterTest.groovy
@@ -469,7 +469,7 @@ class HomeAssistantConverterTest extends Specification {
   def "should set suggested_area when haArea is configured"() {
     given:
     def relayDeviceConfig = new DeviceConfiguration("myRelay", "Test relay", DeviceType.RELAY, [state: new SimulatedConnector(1)],
-      [:], ["haArea": "Living Room"])
+      [:], ["area": "Living Room"])
     GatewayConfiguration gateway = gateway([relayDeviceConfig])
     def deviceRegistry = deviceRegistryFactory.create(gateway)
 
@@ -498,7 +498,7 @@ class HomeAssistantConverterTest extends Specification {
   def "should set suggested_area on trigger components when haArea is configured"() {
     given:
     def switchButtonDeviceConfig = new DeviceConfiguration("mySwitchButton", "Test button", DeviceType.SWITCH_BUTTON,
-      [state: new SimulatedConnector(1)], [:], [haComponent: "device_automation", "haArea": "Hallway"])
+      [state: new SimulatedConnector(1)], [:], [haComponent: "device_automation", "area": "Hallway"])
     GatewayConfiguration gateway = gateway([switchButtonDeviceConfig])
     def deviceRegistry = deviceRegistryFactory.create(gateway)
 

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantPublisherIT.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantPublisherIT.groovy
@@ -58,7 +58,7 @@ class HomeAssistantPublisherIT extends MqttSpecification {
         it.topic ==~ /homeassistant\/[a-zA-Z_-]*\/simulated_gateway\/${device.id}\/config/
       }.payload
       Map parsedConfig = jsonSlurper.parseText(configPayload) as Map
-      assert parsedConfig.state_topic == "homie/simulated_gateway/${device.id}/state"
+      assert parsedConfig.state_topic ==~ /homie\/simulated_gateway\/${device.id}\/.+/
       assert parsedConfig.device.manufacturer == "Aetas"
     }
 	}

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantPublisherTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/homeassistant/HomeAssistantPublisherTest.groovy
@@ -14,7 +14,7 @@ class HomeAssistantPublisherTest extends Specification {
 
 	MqttClientStub mqttClientStub = new MqttClientStub()
 
-	HomeAssistantDevice haDevice = new HomeAssistantDevice([], "manufacturerTestName", "modelTestName", "deviceTestName", "fwTestVersion", "viaDeviceTestValue")
+  HomeAssistantDevice haDevice = new HomeAssistantDevice([], "manufacturerTestName", "modelTestName", "deviceTestName", "fwTestVersion", "viaDeviceTestValue", null)
 
 	void setup() {
 		mqttClientStub.connect(new MqttMessage("", "", 1, true), true)

--- a/src/test/groovy/com/mqgateway/core/gatewayconfig/parser/YamlParserTest.groovy
+++ b/src/test/groovy/com/mqgateway/core/gatewayconfig/parser/YamlParserTest.groovy
@@ -31,8 +31,7 @@ class YamlParserTest extends Specification {
     gateway.devices[0].name == "Workshop light"
     gateway.devices[0].connectors.state != null
     gateway.devices[0].connectors.state instanceof SimulatedConnector
-    (gateway.devices[0].connectors.state as SimulatedConnector).pin == 12
-    gateway.devices[0].config.stringValue == "1"
-    gateway.devices[0].config.intValue == "300"
+    (gateway.devices[0].connectors.state as SimulatedConnector).pin == 1
+    gateway.devices[0].config.haComponent == "light"
   }
 }

--- a/src/test/resources/example.gateway.yaml
+++ b/src/test/resources/example.gateway.yaml
@@ -8,21 +8,194 @@ devices:
     connectors:
       state:
         source: HARDWARE
-        pin: 12
+        pin: 1
     config:
-      stringValue: "1"
-      intValue: 300
+      haComponent: "light"
   - id: "workshop_light_switch"
     type: SWITCH_BUTTON
     name: "Workshop light switch"
     connectors:
       state:
         source: HARDWARE
-        pin: 13
+        pin: 2
+  - id: "workshop_motion"
+    type: MOTION_DETECTOR
+    name: "Workshop motion detector"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 3
+
+  - id: "bedroom_light_relay"
+    type: RELAY
+    name: "Bedroom light relay"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 4
+    config:
+      haComponent: "light"
+      area: "bedroom"
   - id: "bedroom_light_switch"
     type: SWITCH_BUTTON
     name: "Bedroom light switch"
     connectors:
       state:
         source: HARDWARE
+        pin: 5
+    config:
+      area: "bedroom"
+  - id: "bedroom_temperature"
+    type: TEMPERATURE
+    name: "Bedroom temperature"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 6
+    config:
+      area: "bedroom"
+  - id: "bedroom_shutter_stop_relay"
+    type: RELAY
+    name: "Bedroom shutter stop relay"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 7
+  - id: "bedroom_shutter_updown_relay"
+    type: RELAY
+    name: "Bedroom shutter up-down relay"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 8
+  - id: "bedroom_shutter"
+    type: SHUTTER
+    name: "Bedroom shutter"
+    internalDevices:
+      stopRelay:
+        referenceId: "bedroom_shutter_stop_relay"
+      upDownRelay:
+        referenceId: "bedroom_shutter_updown_relay"
+    config:
+      fullOpenTimeMs: 25000
+      fullCloseTimeMs: 22000
+      area: "bedroom"
+
+  - id: "living_room_light_relay"
+    type: RELAY
+    name: "Living room light relay"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 9
+  - id: "living_room_light_switch1"
+    type: SWITCH_BUTTON
+    name: "Living room light switch 1"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 10
+  - id: "living_room_light_switch2"
+    type: SWITCH_BUTTON
+    name: "Living room light switch 2"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 11
+  - id: "living_room_light"
+    type: LIGHT
+    name: "Living room light"
+    internalDevices:
+      relay:
+        referenceId: "living_room_light_relay"
+      switch1:
+        referenceId: "living_room_light_switch1"
+      switch2:
+        referenceId: "living_room_light_switch2"
+    config:
+      area: "living room"
+  - id: "living_room_shutter_stop_relay"
+    type: RELAY
+    name: "Living room shutter stop relay"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 12
+  - id: "living_room_shutter_updown_relay"
+    type: RELAY
+    name: "Living room shutter up-down relay"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 13
+  - id: "living_room_shutter"
+    type: SHUTTER
+    name: "Living room shutter"
+    internalDevices:
+      stopRelay:
+        referenceId: "living_room_shutter_stop_relay"
+      upDownRelay:
+        referenceId: "living_room_shutter_updown_relay"
+    config:
+      fullOpenTimeMs: 28000
+      fullCloseTimeMs: 24000
+      area: "living room"
+
+  - id: "kitchen_light"
+    type: RELAY
+    name: "Kitchen light"
+    connectors:
+      state:
+        source: HARDWARE
         pin: 14
+    config:
+      haComponent: "light"
+      area: "kitchen"
+  - id: "kitchen_humidity"
+    type: HUMIDITY
+    name: "Kitchen humidity"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 15
+    config:
+      area: "kitchen"
+
+  - id: "garage_gate_button"
+    type: EMULATED_SWITCH
+    name: "Garage gate button"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 16
+  - id: "garage_gate_closed_reed"
+    type: REED_SWITCH
+    name: "Garage gate closed sensor"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 17
+    config:
+      haDeviceClass: "garage_door"
+      area: "garage"
+  - id: "garage_gate"
+    type: GATE
+    name: "Garage gate"
+    internalDevices:
+      actionButton:
+        referenceId: "garage_gate_button"
+      closedReedSwitch:
+        referenceId: "garage_gate_closed_reed"
+    config:
+      haDeviceClass: "garage"
+      area: "garage"
+  - id: "front_door_reed"
+    type: REED_SWITCH
+    name: "Front door sensor"
+    connectors:
+      state:
+        source: HARDWARE
+        pin: 18
+    config:
+      haDeviceClass: "door"
+      area: "garage"

--- a/ui/src/pages/Devices.tsx
+++ b/ui/src/pages/Devices.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Search, Layers } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { Search, Layers, MapPin } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -18,6 +18,20 @@ export default function Devices() {
   const filteredDevices = devices.filter((device) =>
     device.name.toLowerCase().includes(searchQuery.toLowerCase())
   )
+
+  const groupedDevices = useMemo(() => {
+    const groups = new Map<string, Device[]>()
+    for (const device of filteredDevices) {
+      const area = (device.properties.get('area') as string) || 'Other'
+      if (!groups.has(area)) groups.set(area, [])
+      groups.get(area)!.push(device)
+    }
+    return Array.from(groups.entries()).sort((a, b) => {
+      if (a[0] === 'Other') return 1
+      if (b[0] === 'Other') return -1
+      return a[0].localeCompare(b[0])
+    })
+  }, [filteredDevices])
 
   const handleDeviceStateChange = async (deviceId: string, propertyId: string, newValue: any) => {
     try {
@@ -177,35 +191,50 @@ export default function Devices() {
             </p>
           </div>
         ) : (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {filteredDevices.map((device) => (
-              <Card key={device.id} className="flex flex-col">
-                <CardHeader>
-                  <CardTitle className="text-base truncate">{device.name}</CardTitle>
-                  <CardDescription className="text-xs">{device.type}</CardDescription>
-                </CardHeader>
-                <CardContent className="flex-1">
-                  {view === 'config' ? (
-                    <div className="space-y-2 text-sm">
-                      <div className="text-muted-foreground">
-                        <span className="font-medium">ID:</span> {device.id}
-                      </div>
-                      <div className="text-muted-foreground">
-                        <span className="font-medium">Type:</span> {device.type}
-                      </div>
-                      {device.properties.size > 0 && (
-                        <div className="text-muted-foreground">
-                          <span className="font-medium">Properties:</span> {device.properties.size}
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <div className="flex flex-col items-center justify-center h-full min-h-[100px]">
-                      {renderDeviceAction(device)}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+          <div className="space-y-8">
+            {groupedDevices.map(([area, areaDevices]) => (
+              <section key={area}>
+                <div className="flex items-center gap-2 mb-3">
+                  <MapPin className="h-4 w-4 text-muted-foreground" />
+                  <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                    {area}
+                  </h2>
+                  <span className="text-xs text-muted-foreground">
+                    ({areaDevices.length})
+                  </span>
+                </div>
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {areaDevices.map((device) => (
+                    <Card key={device.id} className="flex flex-col">
+                      <CardHeader>
+                        <CardTitle className="text-base truncate">{device.name}</CardTitle>
+                        <CardDescription className="text-xs">{device.type}</CardDescription>
+                      </CardHeader>
+                      <CardContent className="flex-1">
+                        {view === 'config' ? (
+                          <div className="space-y-2 text-sm">
+                            <div className="text-muted-foreground">
+                              <span className="font-medium">ID:</span> {device.id}
+                            </div>
+                            <div className="text-muted-foreground">
+                              <span className="font-medium">Type:</span> {device.type}
+                            </div>
+                            {device.properties.size > 0 && (
+                              <div className="text-muted-foreground">
+                                <span className="font-medium">Properties:</span> {device.properties.size}
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="flex flex-col items-center justify-center h-full min-h-[100px]">
+                            {renderDeviceAction(device)}
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </section>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds `area` per-device config option that sets `suggested_area` in Home Assistant MQTT discovery payloads, allowing devices to be automatically assigned to an area without manual steps
- Adds `@JsonInclude(NON_NULL)` on `HomeAssistantDevice` to omit null fields from discovery JSON
- Documents all HA device config options (`haComponent`, `haDeviceClass`, `haEntityName`, `area`) in the integration docs
- Includes tests for `suggested_area` on regular components and trigger components

## Usage
```yaml
devices:
  - id: "living_room_light"
    name: "Living room light"
    type: RELAY
    connectors:
      state:
        gpio: 17
    config:
      area: "Living Room"
```

## Files changed
- `HomeAssistantComponent.kt` — added `suggestedArea` to `HomeAssistantDevice` with `@JsonInclude(NON_NULL)`
- `HomeAssistantConverter.kt` — reads `area` from device config, passes to `HomeAssistantDevice`
- `HomeAssistantConverterTest.groovy` — 3 new test cases
- `HomeAssistantPublisherTest.groovy` — updated constructor for new `HomeAssistantDevice` param
- `integration.md` — documented all HA device config options