### PR TITLE
Fix race in HomieDeviceIT

### DIFF
--- a/src/test/groovy/com/mqgateway/homie/HomieDeviceIT.groovy
+++ b/src/test/groovy/com/mqgateway/homie/HomieDeviceIT.groovy
@@ -9,15 +9,17 @@ import com.mqgateway.utils.MqttSpecification
 import groovy.yaml.YamlSlurper
 import io.micronaut.context.ApplicationContext
 import io.micronaut.runtime.server.EmbeddedServer
+import java.util.concurrent.CopyOnWriteArraySet
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Timeout
 import spock.util.concurrent.BlockingVariable
+import spock.util.concurrent.PollingConditions
 
 @Timeout(30)
 class HomieDeviceIT extends MqttSpecification {
 
-  static Set<MqttMessage> receivedMessages = []
+  static Set<MqttMessage> receivedMessages = new CopyOnWriteArraySet<>()
   YamlSlurper slurper = new YamlSlurper()
 
   static BlockingVariable<Boolean> mqGatewayIsReady = new BlockingVariable<>()
@@ -65,11 +67,15 @@ class HomieDeviceIT extends MqttSpecification {
 
     then:
     mqGatewayIsReady.get()
-    !receivedMessages.isEmpty()
-    gatewayConfiguration.devices.forEach { Map device ->
-      assert receivedMessages.find { it.topic == "homie/simulated_gateway/${device.id}/\$name" }.payload == device.name
+
+    and:
+    new PollingConditions(timeout: 10).eventually {
+      assert !receivedMessages.isEmpty()
+      gatewayConfiguration.devices.forEach { Map device ->
+        assert receivedMessages.find { it.topic == "homie/simulated_gateway/${device.id}/\$name" }?.payload == device.name
+      }
+      assert receivedMessages.contains(new MqttMessage("homie/simulated_gateway/nonExistingDevice1", "", 0, false)) // deleting retained message
     }
-    receivedMessages.contains(new MqttMessage("homie/simulated_gateway/nonExistingDevice1", "", 0, false)) // deleting retained message
   }
 
   def "should initialize devices properties after UniGateway is connected to MQTT"() {


### PR DESCRIPTION
## Summary

- store asynchronously received MQTT messages in a thread-safe `CopyOnWriteArraySet`
- use Spock `PollingConditions` to wait until all expected startup publications are observable
- avoid dereferencing a missing message while MQTT callbacks are still completing

## Root cause

The wildcard MQTT subscription adds messages from an asynchronous callback while the test iterates over `receivedMessages`. The previous Groovy set literal was backed by a non-thread-safe `LinkedHashSet`, which intermittently threw `ConcurrentModificationException`.

Waiting for the `ready` message guarantees that startup reached that state, but does not guarantee that every wildcard-subscription callback has already completed.

Observed in:
- https://github.com/unigateway/unigateway/actions/runs/31647454644/job/94284221284
- https://github.com/unigateway/unigateway/actions/runs/31647388147
- https://github.com/unigateway/unigateway/actions/runs/31305398678
- https://github.com/unigateway/unigateway/actions/runs/31129314342

## Impact

This stabilizes the integration test without changing production behavior.

## Validation

- `git diff --check`
- verified the branch is one commit ahead of `main` and modifies only `HomieDeviceIT.groovy`
- local Gradle execution was not possible because the environment could not download the Gradle wrapper distribution; CI should perform the full test run