### PR TITLE
Bump nanoid to 3.3.18

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7350,9 +7350,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the transitive Nano ID lockfile resolution from 3.3.17 to 3.3.18
- fix CVE-2026-67213 / GHSA-2v37-7h3g-55p8

## Verification

- `./gradlew check shadowJar`
- GitHub Advisory API reports no reviewed advisories affecting `nanoid@3.3.18`
